### PR TITLE
fix: Resolve permission errors by replacing run-as with su

### DIFF
--- a/desktop/flipper-server/src/devices/android/androidContainerUtility.tsx
+++ b/desktop/flipper-server/src/devices/android/androidContainerUtility.tsx
@@ -211,7 +211,7 @@ export function executeCommandAsApp(
     deviceId,
     app,
     command,
-    `run-as '${app}'`,
+    `su $(su -c 'stat -c "%u" /data/data/${app}')`,
   );
 }
 


### PR DESCRIPTION
Resolve the https://github.com/facebook/flipper/issues/92 issue. (Verified working on Galaxy, Android 13)

---

The previous `run-as` command was unstable on certain devices and Android versions, sometimes failing to acquire the necessary permissions.

This commit resolves the issue by directly looking up the application's UID based on its data directory ownership and then using the `su` command to switch to that user. This approach is more robust and explicitly uses the application's permissions.

Change-set: `run-as '${app}'` -> `su $(su -c 'stat -c "%u" /data/data/${app}')`
Note: This change requires a rooted device.